### PR TITLE
Update the Calendar API to get only the upcoming Onelives

### DIFF
--- a/src/main/java/org/sefgobal/dataholder/api/CalendarAPI.java
+++ b/src/main/java/org/sefgobal/dataholder/api/CalendarAPI.java
@@ -25,7 +25,6 @@ public class CalendarAPI {
     public void getUpcomingOnelives(HttpServletRequest request, HttpServletResponse response) {
         String googleApiKey = System.getenv("GOOGLE_API_KEY");
         String oneliveCalendarId = System.getenv("ONELIVE_CALENDAR_ID");
-
         //Get the current time and format it to the RFC3339 format
         ZonedDateTime timeNow = ZonedDateTime.now();
         DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:'00':'00'Z");

--- a/src/main/java/org/sefgobal/dataholder/api/CalendarAPI.java
+++ b/src/main/java/org/sefgobal/dataholder/api/CalendarAPI.java
@@ -27,6 +27,7 @@ public class CalendarAPI {
         String googleApiKey = System.getenv("GOOGLE_API_KEY");
         String oneliveCalendarId = System.getenv("ONELIVE_CALENDAR_ID");
 
+        //Get the current time and format it to the RFC3339 format
         ZonedDateTime timeNow = ZonedDateTime.now();
         DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:'00':'00'Z");
         String formattedDateTime = timeNow.format(format);

--- a/src/main/java/org/sefgobal/dataholder/api/CalendarAPI.java
+++ b/src/main/java/org/sefgobal/dataholder/api/CalendarAPI.java
@@ -18,7 +18,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 @CrossOrigin(origins = "*", allowedHeaders = "*")
-
 @RestController
 public class CalendarAPI {
 
@@ -33,9 +32,12 @@ public class CalendarAPI {
         String formattedDateTime = timeNow.format(format);
         formattedDateTime = formattedDateTime.substring(0, 22) + ":" + formattedDateTime.substring(22);
         formattedDateTime = formattedDateTime.replace(":", "%3A").replace("+", "%2B");
-
-        String url = "https://www.googleapis.com/calendar/v3/calendars/" + oneliveCalendarId +
-                "/events?timeMin=" + formattedDateTime + "&key=" + googleApiKey;
+        String url = "https://www.googleapis.com/calendar/v3/calendars/" +
+                oneliveCalendarId +
+                "/events?timeMin=" +
+                formattedDateTime +
+                "&key=" +
+                googleApiKey;
 
         HttpClient httpclient = HttpClients.createDefault();
         HttpGet executor = new HttpGet(url);

--- a/src/main/java/org/sefgobal/dataholder/api/CalendarAPI.java
+++ b/src/main/java/org/sefgobal/dataholder/api/CalendarAPI.java
@@ -4,6 +4,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClients;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,7 +14,10 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
+@CrossOrigin(origins = "*", allowedHeaders = "*")
 
 @RestController
 public class CalendarAPI {
@@ -22,8 +26,15 @@ public class CalendarAPI {
     public void getUpcomingOnelives(HttpServletRequest request, HttpServletResponse response) {
         String googleApiKey = System.getenv("GOOGLE_API_KEY");
         String oneliveCalendarId = System.getenv("ONELIVE_CALENDAR_ID");
+
+        ZonedDateTime timeNow = ZonedDateTime.now();
+        DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:'00':'00'Z");
+        String formattedDateTime = timeNow.format(format);
+        formattedDateTime = formattedDateTime.substring(0, 22) + ":" + formattedDateTime.substring(22);
+        formattedDateTime = formattedDateTime.replace(":", "%3A").replace("+", "%2B");
+
         String url = "https://www.googleapis.com/calendar/v3/calendars/" + oneliveCalendarId +
-                "/events?key=" + googleApiKey;
+                "/events?timeMin=" + formattedDateTime + "&key=" + googleApiKey;
 
         HttpClient httpclient = HttpClients.createDefault();
         HttpGet executor = new HttpGet(url);


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #19 

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
Update the Calendar API to get only the upcoming Onelives

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
Got the current time and formatted it to the RFC3339 date/time format which is used in google APIs.
Added the "timeMin" filter to get only the upcoming events.

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 
N/A

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
Ubuntu 19.04
OpenJDK version 11.0.5

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
N/A